### PR TITLE
Make the abstract spicier

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -215,7 +215,7 @@ In the typical case where adjacent entries in the vector are highly correlated, 
 
 \subsection{Python binding}
 
-We have implemented a Python binding to the graph implementations in \texttt{libbdsg}
+We have implemented a Python binding to the graph implementations in \texttt{libbdsg} using Pybind11 \cite{pybind11}.
 This allows the data structures to be used in Python applications, significantly lowering the barrier-to-entry for pangenomic application developers.
 This functionality is documented at \url{https://pangenome.github.io/odgi/odgipy.html}, and a tutorial is available at \url{https://odgi.readthedocs.io/en/latest/rst/tutorial.html}.
 This documentation also serves as useful introduction to the \textsc{HandleGraph} API.

--- a/main.tex
+++ b/main.tex
@@ -28,7 +28,8 @@ Pangenomics is a growing field within computational genomics.
 Many pangenomic analyses use bidirected sequence graphs as their core data model.
 However, implementing and correctly using this data model can be difficult, and the scale of pangenomic data sets can be challenging to work at.
 Here we present a stack of two C++ libraries, \texttt{libbdsg} and \texttt{libhandlegraph}, which use a simple, field-proven interface, with a Python binding, designed to expose elementary features of these graphs while preventing common graph manipulation mistakes.
-Through experiments with a diverse collection of pangenome graphs, we demonstrate that these tools allow for efficient construction and manipulation of large genome graphs with dense variation.
+Using a diverse collection of pangenome graphs, we demonstrate that these tools allow for efficient construction and manipulation of large genome graphs with dense variation.
+For instance, the memory and memory usage is up to an order of magnitude better than the pre-existing graph implementation in the \textsc{vg} toolkit, which is now transitioning to \texttt{libbdsg}'s graph implementations.
 
 \end{abstract}
 
@@ -54,15 +55,16 @@ Using na\"ive data structures to identify and provide random access to elements 
 However, the total information content is only incrementally more than in the total sequence set of the pangenome.
 This suggests that significant memory savings should be possible.
 
-The variation graph toolkit (\textsc{vg}) \cite{Garrison_2018} provides a cautionary tale of such a na\"ive implementation.
-\textsc{vg} uses full-width machine words as identifiers for graph elements, stores the elements and graph topology in a set of hash tables, and links identifiers to elements with raw pointers.
-Loading the 1000 Genomes Project's variant set into the \textsc{vg} toolkit consumes more than 300 GB of memory, which is $\sim$30 times as large as the serialized representation \cite{Garrison_2019}.
+Early versions variation graph toolkit (\textsc{vg}) \cite{Garrison_2018} provides a cautionary tale of such a na\"ive implementation.
+\textsc{vg} usds full-width machine words as identifiers for graph elements, stored the elements and graph topology in a set of hash tables, and linked identifiers to elements with raw pointers.
+Loading the 1000 Genomes Project's variant set into the \textsc{vg} toolkit consumed more than 300 GB of memory, which is $\sim$30 times as large as the serialized representation \cite{Garrison_2019}.
 
-Although \textsc{vg} provides a memory-efficient succinct representation of the graph (\textsc{xg}) that is used during read mapping and variant calling, the succinct representation does not allow for dynamic updates to the graph.
-As a result, graph-modifying steps in \textsc{vg} pangenomic analysis pipelines must break large graphs into smaller pieces, often connected components that correspond to chromosomes.
+Although \textsc{vg} provided a memory-efficient succinct representation of the graph (\textsc{xg}) that is used during read mapping and variant calling, the succinct representation did not allow for dynamic updates to the graph.
+As a result, graph-modifying steps in \textsc{vg} pangenomic analysis pipelines had to break large graphs into smaller pieces, often connected components that correspond to chromosomes.
+Unfortunately, this strategy is not tenable for all graphs.
 For instance, many whole genome alignment and assembly graphs consist of a single giant component that cannot be partitioned easily.
 
-To overcome this limitation, we have developed three new graph genome data structures that are both dynamic, in that they allow efficient updates and edits, \emph{and} succinct, in that they require memory on the order of the graph's information content,.
+To overcome this limitation, we have developed three new graph genome data structures that are both dynamic, in that they allow efficient updates and edits, \emph{and} succinct, in that they require memory on the order of the graph's information content.
 Here, we compare the performance of these data structures to those in \textsc{vg} and \textsc{xg} using a diverse collection of genome graphs obtained during our work in graphical pangenomics.
 
 In addition to demonstrating the possibility of working with large, complex graphs in small amounts of memory, these implementations expose a common API based on the \textsc{HandleGraph} model described below.
@@ -272,8 +274,9 @@ However, it provides significantly better iteration performance for nodes (handl
 We have presented a set of simple formalisms, the \textsc{HandleGraph} abstraction, which provides a coherent interface to address and manipulate the components of a genome variation graph.
 To explore the utility of this model, we implemented data structures to encode variation graphs and matched them to this interface.
 This allowed us to directly compare these \textsc{HandleGraph} implementations on a diverse set of genome graphs obtained during our research.
-These experiments reveal that the computational expense of \textsc{vg} is not a necessary feature of genome graph implementations.
+These experiments reveal that genome graphs need not pay the computational expense of the early versions of \textsc{vg}.
 The best-performing models require an order of magnitude less memory than \textsc{vg} while providing higher performance for basic graph access operation and element iteration.
+For these reasons, \textsc{vg} is currently in the process of transitioning to using these newer graph implementations. 
 
 The efficiency of these methods and their encapsulation within a coherent programming interface will support their reuse within a diverse set of application domains.
 Variation graphs have deep similarity with graphs used in assembly; these libraries could be used as the basis for assembly methods.

--- a/references.bib
+++ b/references.bib
@@ -141,3 +141,10 @@
   year={2018},
   publisher={Oxford University Press}
 }
+
+@misc{pybind11,
+   author = {Wenzel Jakob and Jason Rhinelander and Dean Moldovan},
+   year = {2017},
+   note = {https://github.com/pybind/pybind11},
+   title = {pybind11 -- Seamless operability between C++11 and Python}
+}


### PR DESCRIPTION
I added a sentence to the abstract about the comparative performance to early VG for extra spiciness. I also went through the text and made references to VG sucking actually talk about "earlier versions of VG" sucking. There's new a clause in the abstract and a sentence in the discussion indicating that VG is currently in process of transitioning to the new graph implementations.

Also, I seem to have accidentally deleted a sentence that I shouldn't have, so that's fixed now.

@ekg @adamnovak @glennhickey  I think we're ready to roll after this, right?