### PR TITLE
link to pangenome docs

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -13,7 +13,7 @@
 %\title{libbdsg and libhandlegraph: High-performance sequence graph implementations for graphical pangenomics}
 \title{Succinct dynamic genome variation graphs} % for graphical pangenomics}
   %libbdsg and libhandlegraph: High-performance sequence graph implementations for graphical pangenomics}
-\author{Jordan M. Eizenga$^*$ \and Adam M. Novak$^*$ \and Emily Kobayashi \and Flavia Villani  \and Cecilia Cisar \and Glenn Hickey \and Vincenza Colonna \and Benedict Paten \and Erik Garrison}
+\author{Jordan M. Eizenga$^*$ \and Adam M. Novak$^*$ \and Emily Kobayashi \and Flavia Villani  \and Cecilia Cisar \and Glenn Hickey \and Vincenza Colonna \and Simon Heumos \and Benedict Paten \and Erik Garrison}
 
 
 \newcommand{\vocab}{\textbf}
@@ -224,7 +224,7 @@ This documentation also serves as useful introduction to the \textsc{HandleGraph
 \subsection{Code availability}
 
 Both \texttt{libhandlegraph} and \texttt{libbdsg} are open source under an MIT License.
-They are available on GitHub at \url{https://github.com/vgteam/libhandlegraph} and \url{https://github.com/vgteam/libbdsg}.
+They are available on GitHub at \url{https://github.com/vgteam/libhandlegraph} and \url{https://github.com/vgteam/libbdsg}. Extensive documentation of these libraries and their respective graph implementations is available at \url{https://pangenome.github.io/}.
 
 \section{Evaluation}
 


### PR DESCRIPTION
Link to our Practical Graphical Pangenomics documentation where people can find a deep read for hg, pg, odgi, vg and xg