### PR TITLE
Drop pangenome.github.io link

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -296,7 +296,6 @@ This documentation also serves as useful introduction to the \textsc{HandleGraph
 Both \texttt{libhandlegraph} and \texttt{libbdsg} are open source under an MIT License.
 They are available on GitHub at \url{https://github.com/vgteam/libhandlegraph} and \url{https://github.com/vgteam/libbdsg}.
 Documentation for the two libraries, including the C++ handle graph API, \textsc{HashGraph}, \textsc{odgi}, and \textsc{PackedGraph}, is available at \url{https://bdsg.readthedocs.io} alongside the documentation for the Python binding.
-Additional documentation, focusing on \textsc{odgi} and its associated command-line tool, is available at \url{https://pangenome.github.io}.
 
 \end{methods}
 


### PR DESCRIPTION
We decided to just talk about the RtD docs in this publication since they belong to the libraries we're publishing.